### PR TITLE
Fix release district logic

### DIFF
--- a/EnhancedDistrictServices.csproj
+++ b/EnhancedDistrictServices.csproj
@@ -94,6 +94,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Images\" />
+    <Folder Include="Source\Patches\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Source/DistrictPark/DistrictManagerReleasePatch.cs
+++ b/Source/DistrictPark/DistrictManagerReleasePatch.cs
@@ -3,23 +3,33 @@
 namespace EnhancedDistrictServices
 {
     [HarmonyPatch(typeof(DistrictManager))]
-    [HarmonyPatch("ReleaseDistrict")]
+    [HarmonyPatch("ReleaseDistrictImplementation")]
     public class DistrictManagerReleaseDistrictPatch
     {
-        public static bool Prefix(byte district)
+        public static bool Prefix(byte district, ref District data)
         {
-            Constraints.ReleaseDistrictPark(DistrictPark.FromDistrict(district));
+            var districtPark = DistrictPark.FromDistrict(district);
+            if (districtPark.Name != string.Empty)
+            {
+                Constraints.ReleaseDistrictPark(districtPark);
+            }
+
             return true;
         }
     }
 
     [HarmonyPatch(typeof(DistrictManager))]
-    [HarmonyPatch("ReleasePark")]
+    [HarmonyPatch("ReleaseParkImplementation")]
     public class DistrictManagerReleaseParkPatch
     {
-        public static bool Prefix(byte park)
+        public static bool Prefix(byte park, ref DistrictPark data)
         {
-            Constraints.ReleaseDistrictPark(DistrictPark.FromPark(park));
+            var districtPark = DistrictPark.FromPark(park);
+            if (districtPark.Name != string.Empty)
+            {
+                Constraints.ReleaseDistrictPark(districtPark);
+            }
+
             return true;
         }
     }

--- a/Source/DistrictPark/DistrictPark.cs
+++ b/Source/DistrictPark/DistrictPark.cs
@@ -103,6 +103,27 @@ namespace EnhancedDistrictServices
         }
 
         /// <summary>
+        /// Returns false if the district or park no longer exist.
+        /// </summary>
+        public bool Exists
+        {
+            get
+            {
+                if (District != 0 && (DistrictManager.instance.m_districts.m_buffer[District].m_flags & global::District.Flags.Created) == global::District.Flags.None)
+                {
+                    return false;
+                }
+
+                if (Park != 0 && (DistrictManager.instance.m_parks.m_buffer[Park].m_flags & global::DistrictPark.Flags.Created) == global::DistrictPark.Flags.None)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Returns true if this struct does not refer to a valid district or park.
         /// </summary>
         public bool IsEmpty
@@ -114,13 +135,72 @@ namespace EnhancedDistrictServices
         }
 
         /// <summary>
+        /// Returns true if this specification includes a reference to a campus.
+        /// </summary>
+        public bool IsCampus
+        {
+            get
+            {
+                if (Park != 0)
+                {
+                    var type = DistrictManager.instance.m_parks.m_buffer[Park].m_parkType;
+                    return
+                        type == global::DistrictPark.ParkType.GenericCampus ||
+                        type == global::DistrictPark.ParkType.TradeSchool ||
+                        type == global::DistrictPark.ParkType.LiberalArts ||
+                        type == global::DistrictPark.ParkType.University;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this specification includes a reference to a campus.
+        /// </summary>
+        public bool IsIndustry
+        {
+            get
+            {
+                if (Park != 0)
+                {
+                    var type = DistrictManager.instance.m_parks.m_buffer[Park].m_parkType;
+                    return
+                        type == global::DistrictPark.ParkType.Industry ||
+                        type == global::DistrictPark.ParkType.Farming ||
+                        type == global::DistrictPark.ParkType.Forestry ||
+                        type == global::DistrictPark.ParkType.Ore ||
+                        type == global::DistrictPark.ParkType.Oil;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
         /// Returns true if this specification includes a reference to a park.
         /// </summary>
         public bool IsPark
         {
             get
             {
-                return Park != 0;
+                if (Park != 0)
+                {
+                    var type = DistrictManager.instance.m_parks.m_buffer[Park].m_parkType;
+                    return
+                        type == global::DistrictPark.ParkType.Generic ||
+                        type == global::DistrictPark.ParkType.AmusementPark ||
+                        type == global::DistrictPark.ParkType.Zoo ||
+                        type == global::DistrictPark.ParkType.NatureReserve;
+                }
+                else
+                {
+                    return false;
+                }
             }
         }
 

--- a/Source/EnhancedDistrictServicesMod.cs
+++ b/Source/EnhancedDistrictServicesMod.cs
@@ -12,7 +12,7 @@ namespace EnhancedDistrictServices
     /// </summary>
     public class EnhancedDistrictServicesMod : IUserMod, ILoadingExtension
     {
-        public const string version = "1.0.14";
+        public const string version = "1.0.15";
         public string Name => $"Enhanced District Services {version}";
         public string Description => "Enhanced District Services mod for Cities Skylines, which allows more granular control of services and supply chains.";
 
@@ -70,10 +70,22 @@ namespace EnhancedDistrictServices
                     .tooltip = "Strongly recommend against enabling this legacy feature.  This was originally put in to deal with massive traffic originating from outside connections.  Not needed anymore.";
 
                 ((UIComponent)uiHelper.AddCheckbox(
-                    "Show campus/industrial/park districts in district dropdown menu", 
+                    "Show campus districts in district dropdown menu",
+                    Settings.showCampusDistricts,
+                    b => Settings.showCampusDistricts.value = b))
+                    .tooltip = "Disable this option if you do not wish to be able to see campus districts in the dropdown menu.";
+
+                ((UIComponent)uiHelper.AddCheckbox(
+                    "Show industry districts in district dropdown menu",
+                    Settings.showIndustryDistricts,
+                    b => Settings.showIndustryDistricts.value = b))
+                    .tooltip = "Disable this option if you do not wish to be able to see industry districts in the dropdown menu.";
+
+                ((UIComponent)uiHelper.AddCheckbox(
+                    "Show park districts in district dropdown menu", 
                     Settings.showParkDistricts, 
                     b => Settings.showParkDistricts.value = b))
-                    .tooltip = "Disable this option if you do not wish to be able to see campus/industrial/park districts in the dropdown menu.";
+                    .tooltip = "Disable this option if you do not wish to be able to see park districts in the dropdown menu.";
 
                 ((UIComponent)uiHelper.AddCheckbox(
                     "Show welcome message",

--- a/Source/EnhancedDistrictServicesTool.cs
+++ b/Source/EnhancedDistrictServicesTool.cs
@@ -25,9 +25,9 @@ namespace EnhancedDistrictServices
             EnhancedDistrictServicesUIPanel.Create();
 
             BuildingManager.instance.EventBuildingCreated += Constraints.CreateBuilding;
-            BuildingManager.instance.EventBuildingCreated += TaxiMod.AddTaxiBuilding;
+            BuildingManager.instance.EventBuildingCreated += TaxiMod.RegisterTaxiBuilding;
             BuildingManager.instance.EventBuildingReleased += Constraints.ReleaseBuilding;
-            BuildingManager.instance.EventBuildingReleased += TaxiMod.RemoveTaxiBuilding;
+            BuildingManager.instance.EventBuildingReleased += TaxiMod.DeregisterTaxiBuilding;
         }
 
         protected override void OnDestroy()
@@ -36,9 +36,9 @@ namespace EnhancedDistrictServices
             EnhancedDistrictServicesUIPanel.Destroy();
 
             BuildingManager.instance.EventBuildingCreated -= Constraints.CreateBuilding;
-            BuildingManager.instance.EventBuildingCreated -= TaxiMod.AddTaxiBuilding;
+            BuildingManager.instance.EventBuildingCreated -= TaxiMod.RegisterTaxiBuilding;
             BuildingManager.instance.EventBuildingReleased -= Constraints.ReleaseBuilding;
-            BuildingManager.instance.EventBuildingReleased -= TaxiMod.RemoveTaxiBuilding;
+            BuildingManager.instance.EventBuildingReleased -= TaxiMod.DeregisterTaxiBuilding;
         }
 
         protected override void OnEnable()

--- a/Source/EnhancedDistrictServicesUIPanel.cs
+++ b/Source/EnhancedDistrictServicesUIPanel.cs
@@ -840,6 +840,16 @@ namespace EnhancedDistrictServices
 
             foreach (var districtPark in districtParks)
             {
+                if (!Settings.showCampusDistricts.value && districtPark.IsCampus)
+                {
+                    continue;
+                }
+
+                if (!Settings.showIndustryDistricts.value && districtPark.IsIndustry)
+                {
+                    continue;
+                }
+
                 if (!Settings.showParkDistricts.value && districtPark.IsPark)
                 {
                     continue;

--- a/Source/Serialization/EnhancedDistrictServicesSerializableData.cs
+++ b/Source/Serialization/EnhancedDistrictServicesSerializableData.cs
@@ -42,7 +42,7 @@ namespace EnhancedDistrictServices.Serialization
                     var buildings = Utils.GetSupportedServiceBuildings();
                     foreach (var building in buildings)
                     {
-                        TaxiMod.AddTaxiBuilding(building);
+                        TaxiMod.RegisterTaxiBuilding(building);
                     }
                 }
                 catch (Exception ex)

--- a/Source/TransferManagerAddOfferPatch.cs
+++ b/Source/TransferManagerAddOfferPatch.cs
@@ -24,15 +24,22 @@ namespace EnhancedDistrictServices
                 return true;
             }
 
-            if (material == TransferManager.TransferReason.Taxi && !TaxiMod.CanUseTaxis(offer.Position))
+            if (material == TransferManager.TransferReason.Taxi)
             {
-                Logger.LogMaterial($"TransferManager::AddIncomingOffer: Filtering out {Utils.ToString(ref offer, material)}!", material);
-                var instanceId = CitizenManager.instance.m_citizens.m_buffer[offer.Citizen].m_instance;
-                CitizenManager.instance.m_instances.m_buffer[instanceId].m_flags &= ~CitizenInstance.Flags.WaitingTaxi;
-                CitizenManager.instance.m_instances.m_buffer[instanceId].m_flags |= CitizenInstance.Flags.BoredOfWaiting;
-                CitizenManager.instance.m_instances.m_buffer[instanceId].m_flags |= CitizenInstance.Flags.CannotUseTaxi;
-                CitizenManager.instance.m_instances.m_buffer[instanceId].m_waitCounter = byte.MaxValue;
-                return false;
+                var instance = CitizenManager.instance.m_citizens.m_buffer[offer.Citizen].m_instance;
+                var targetBuilding = CitizenManager.instance.m_instances.m_buffer[instance].m_targetBuilding;
+                var targetPosition = BuildingManager.instance.m_buildings.m_buffer[targetBuilding].m_position;
+
+                if (!TaxiMod.CanUseTaxis(offer.Position, targetPosition))
+                {
+                    Logger.LogMaterial($"TransferManager::AddIncomingOffer: Filtering out {Utils.ToString(ref offer, material)}!", material);
+                    var instanceId = CitizenManager.instance.m_citizens.m_buffer[offer.Citizen].m_instance;
+                    CitizenManager.instance.m_instances.m_buffer[instanceId].m_flags &= ~CitizenInstance.Flags.WaitingTaxi;
+                    CitizenManager.instance.m_instances.m_buffer[instanceId].m_flags |= CitizenInstance.Flags.BoredOfWaiting;
+                    CitizenManager.instance.m_instances.m_buffer[instanceId].m_flags |= CitizenInstance.Flags.CannotUseTaxi;
+                    CitizenManager.instance.m_instances.m_buffer[instanceId].m_waitCounter = byte.MaxValue;
+                    return false;
+                }
             }
 
             Logger.LogMaterial($"TransferManager::AddIncomingOffer: {Utils.ToString(ref offer, material)}!", material);

--- a/Source/TransferManagerAddOfferPatch.cs
+++ b/Source/TransferManagerAddOfferPatch.cs
@@ -24,7 +24,7 @@ namespace EnhancedDistrictServices
                 return true;
             }
 
-            if (material == TransferManager.TransferReason.Taxi)
+            if (material == TransferManager.TransferReason.Taxi && offer.Citizen != 0)
             {
                 var instance = CitizenManager.instance.m_citizens.m_buffer[offer.Citizen].m_instance;
                 var targetBuilding = CitizenManager.instance.m_instances.m_buffer[instance].m_targetBuilding;

--- a/Source/UI/Settings.cs
+++ b/Source/UI/Settings.cs
@@ -11,6 +11,8 @@ namespace EnhancedDistrictServices
 
         public static readonly SavedBool enableDummyCargoTraffic = new SavedBool(nameof(enableDummyCargoTraffic), "EnhancedDistrictServices", true, true);
         public static readonly SavedBool enableSelectOutsideConnection = new SavedBool(nameof(enableSelectOutsideConnection), "EnhancedDistrictServices", false, true);
+        public static readonly SavedBool showCampusDistricts = new SavedBool(nameof(showCampusDistricts), "EnhancedDistrictServices", true, true);
+        public static readonly SavedBool showIndustryDistricts = new SavedBool(nameof(showIndustryDistricts), "EnhancedDistrictServices", true, true);
         public static readonly SavedBool showParkDistricts = new SavedBool(nameof(showParkDistricts), "EnhancedDistrictServices", true, true);
         public static readonly SavedBool showWelcomeMessage = new SavedBool(nameof(showWelcomeMessage), "EnhancedDistrictServices", true, true);
     }

--- a/Source/Vehicles/TaxiMod.cs
+++ b/Source/Vehicles/TaxiMod.cs
@@ -7,7 +7,7 @@ namespace EnhancedDistrictServices
     {
         private static List<ushort> m_taxiBuildings = new List<ushort>();
 
-        public static void AddTaxiBuilding(ushort building)
+        public static void RegisterTaxiBuilding(ushort building)
         {
             if (BuildingManager.instance.m_buildings.m_buffer[building].Info?.GetSubService() == ItemClass.SubService.PublicTransportTaxi)
             {
@@ -18,14 +18,15 @@ namespace EnhancedDistrictServices
             }
         }
 
-        public static void RemoveTaxiBuilding(ushort building)
+        public static void DeregisterTaxiBuilding(ushort building)
         {
             m_taxiBuildings.Remove(building);
         }
 
-        public static bool CanUseTaxis(Vector3 position)
+        public static bool CanUseTaxis(Vector3 startPosition, Vector3 endPosition)
         {
-            var districtPark = DistrictPark.FromPosition(position);
+            var startDistrictPark = DistrictPark.FromPosition(startPosition);
+            var endDistrictPark = DistrictPark.FromPosition(endPosition);
 
             // Now see whether any taxi buildings serve this position.
             for (int i = 0; i < m_taxiBuildings.Count; i++)
@@ -34,7 +35,7 @@ namespace EnhancedDistrictServices
                 if (BuildingManager.instance.m_buildings.m_buffer[buildingId].Info?.GetSubService() == ItemClass.SubService.PublicTransportTaxi)
                 {
                     var districtParkServed = Constraints.OutputDistrictParkServiced((ushort)buildingId);
-                    if (districtPark.IsServedBy(districtParkServed))
+                    if (startDistrictPark.IsServedBy(districtParkServed) && endDistrictPark.IsServedBy(districtParkServed))
                     {
                         return true;
                     }


### PR DESCRIPTION
Fix release district logic so that references to the erased district are now handled properly.  

Fix taxi logic so that both the start and end locations are now considered when deciding whether to allow the human to take a taxi.  

Add additional filters for campus/industry/park districts.