### PR TITLE
Added outside connection selection

### DIFF
--- a/Source/EnhancedDistrictServicesTool.cs
+++ b/Source/EnhancedDistrictServicesTool.cs
@@ -75,6 +75,7 @@ namespace EnhancedDistrictServices
         {
             base.OnDisable();
             EnhancedDistrictServicesUIPanel.Instance?.UIDistrictsDropDown?.ClosePopup();
+            EnhancedDistrictServicesUIPanel.Instance?.UIConnectionsDropDown?.ClosePopup();
             EnhancedDistrictServicesUIPanel.Instance?.UIVehiclesDropDown?.ClosePopup();
             EnhancedDistrictServicesUIPanel.Instance?.Hide();
 

--- a/Source/EnhancedDistrictServicesUIPanelBase.cs
+++ b/Source/EnhancedDistrictServicesUIPanelBase.cs
@@ -133,6 +133,9 @@ namespace EnhancedDistrictServices
         public UILabel UIDistrictsSummary;
         public UICheckboxDropDown UIDistrictsDropDown;
 
+        public UILabel UIConnectionsSummary;
+        public UICheckboxDropDown UIConnectionsDropDown;
+
         public UICheckBox UIVehicleDefaultsCheckBox;
         public UILabel UIVehiclesSummary;
         public UICheckboxDropDown UIVehiclesDropDown;
@@ -152,7 +155,7 @@ namespace EnhancedDistrictServices
 
             name = GetType().Name;
             backgroundSprite = "MenuPanel2";
-            size = new Vector2(m_componentWidth + 2 * m_componentPadding, 200);
+            size = new Vector2(m_componentWidth + 2 * m_componentPadding, 230);
 
             UITitle = AttachUILabelTo(this, 3, 3, height: 25);
             UITitle.textAlignment = UIHorizontalAlignment.Center;
@@ -187,6 +190,12 @@ namespace EnhancedDistrictServices
             UIDistrictsDropDown = AttachUICheckboxDropDownTo(this, 3, 148 + 3);
             UIDistrictsDropDown.eventDropdownOpen += UIEventDropdownOpen;
             UIDistrictsDropDown.eventDropdownClose += UIEventDropdownClose;
+
+            UIConnectionsSummary = AttachUILabelTo(this, 3, 148);
+            UIConnectionsSummary.zOrder = 0;
+            UIConnectionsDropDown = AttachUICheckboxDropDownTo(this, 3, 148 + 3);
+            UIConnectionsDropDown.eventDropdownOpen += UIEventDropdownOpen;
+            UIConnectionsDropDown.eventDropdownClose += UIEventDropdownClose;
 
             UIVehicleDefaultsCheckBox = AttachUICheckBoxTo(this, 141, 88);
             UIVehicleDefaultsCheckBox.label = AttachUILabelTo(UIVehicleDefaultsCheckBox, -138, 0);

--- a/Source/Serialization/Datav4.cs
+++ b/Source/Serialization/Datav4.cs
@@ -18,7 +18,7 @@ namespace EnhancedDistrictServices.Serialization
         public List<int>[] BuildingToBuildingServiced = new List<int>[BuildingManager.MAX_BUILDING_COUNT];
         public int GlobalOutsideConnectionIntensity = 15;
         public int GlobalOutsideToOutsideMaxPerc = 10;
-
+        
         private static readonly string m_id = "EnhancedDistrictServices_v4";
 
         public string Id
@@ -28,6 +28,9 @@ namespace EnhancedDistrictServices.Serialization
                 return m_id;
             }
         }
+
+        public List<int>[] InputBuildingToOutsideConnectionsIds = new List<int>[BuildingManager.MAX_BUILDING_COUNT];
+        public List<int>[] OutputBuildingToOutsideConnectionsIds = new List<int>[BuildingManager.MAX_BUILDING_COUNT];
 
         public static bool TryLoadData(EnhancedDistrictServicesSerializableData loader, out Datav4 data)
         {

--- a/Source/TransferManagerInfo.cs
+++ b/Source/TransferManagerInfo.cs
@@ -317,6 +317,23 @@ namespace EnhancedDistrictServices
             }
         }
 
+        public static string GetServiceTypeText(int building)
+        {
+            if (building == 0) return string.Empty;
+
+            var buildingInfo = BuildingManager.instance.m_buildings.m_buffer[building].Info;
+            var service = buildingInfo.GetService();
+            var subService = buildingInfo.GetSubService();
+            if (buildingInfo.GetAI() is OutsideConnectionAI)
+            {
+                if (buildingInfo.GetService() == ItemClass.Service.Road) return $"Road";
+
+                return $"{subService}";
+            }
+
+            return $"{service}";
+        }
+
         /// <summary>
         /// Returns a descriptive text indicating the supply chain destination buildings that the given building
         /// will ship to.
@@ -338,7 +355,7 @@ namespace EnhancedDistrictServices
                 txtItems.Add($"All local areas");
             }
 
-            if (Constraints.OutputOutsideConnections(building))
+            if (Constraints.AllOutputOutsideConnections(building))
             {
                 txtItems.Add($"All outside connections");
             }
@@ -407,7 +424,7 @@ namespace EnhancedDistrictServices
                 txtItems.Add($"All local areas");
             }
 
-            if (Constraints.InputOutsideConnections(building))
+            if (Constraints.AllInputOutsideConnections(building))
             {
                 txtItems.Add($"All outside connections");
             }
@@ -474,8 +491,9 @@ namespace EnhancedDistrictServices
                     return true;
                 }
 
+                // TODO handle connection ids
                 // Assume for now that the outside connection can supply the building with the materials it needs.
-                if (Constraints.InputOutsideConnections(building))
+                if (Constraints.AllInputOutsideConnections(building))
                 {
                     return true;
                 }

--- a/Source/TransferManagerMod.cs
+++ b/Source/TransferManagerMod.cs
@@ -9,7 +9,7 @@ namespace EnhancedDistrictServices
 {
     public static class TransferManagerMod
     {
-        private static readonly Randomizer m_randomizer = new Randomizer(0);
+        private static Randomizer m_randomizer = new Randomizer(0);
 
         private static readonly TransferManager.TransferOffer[] m_outgoingOffers;
         private static readonly TransferManager.TransferOffer[] m_incomingOffers;
@@ -763,7 +763,7 @@ namespace EnhancedDistrictServices
                         material);
                     return true;
                 }
-                else if (Constraints.OutputOutsideConnections(responseBuilding))
+                else if (Constraints.OutputOutsideConnections(responseBuilding, requestBuilding))
                 {
                     Logger.LogMaterial(
                         $"TransferManager::IsValidLowPriorityOffer: {Utils.ToString(ref responseOffer, material)}, matched inside to outside offer",
@@ -783,7 +783,7 @@ namespace EnhancedDistrictServices
             if (TransferManagerInfo.IsOutsideBuilding(responseBuilding))
             {
                 // Don't be so aggressive in trying to serve low priority orders with outside connections.
-                if (requestPriority > 1 && Constraints.InputOutsideConnections(requestBuilding))
+                if (requestPriority > 1 && Constraints.InputOutsideConnections(requestBuilding, responseBuilding))
                 {
                     Logger.LogMaterial(
                         $"TransferManager::IsValidLowPriorityOffer: {Utils.ToString(ref responseOffer, material)}, matched outside to inside offer",

--- a/Source/UI/CopyPaste.cs
+++ b/Source/UI/CopyPaste.cs
@@ -13,8 +13,10 @@
             Constraints.SetAllInputLocalAreas(building, Constraints.InputAllLocalAreas(BuildingTemplate));
             Constraints.SetAllOutputLocalAreas(building, Constraints.OutputAllLocalAreas(BuildingTemplate));
 
-            Constraints.SetAllInputOutsideConnections(building, Constraints.InputOutsideConnections(BuildingTemplate));
-            Constraints.SetAllOutputOutsideConnections(building, Constraints.OutputOutsideConnections(BuildingTemplate));
+            Constraints.SetAllInputOutsideConnections(building, Constraints.AllInputOutsideConnections(BuildingTemplate));
+            Constraints.SetInputOutsideConnectionIds(building, Constraints.InputOutsideConnectionIds(BuildingTemplate));
+            Constraints.SetAllOutputOutsideConnections(building, Constraints.AllOutputOutsideConnections(BuildingTemplate));
+            Constraints.SetOutputOutsideConnectionIds(building, Constraints.OutputOutsideConnectionIds(BuildingTemplate));
 
             var inputDistrictsServed = Constraints.InputDistrictParkServiced(BuildingTemplate);
             if (inputDistrictsServed != null)


### PR DESCRIPTION
Added possibility to choose individual outside connections.

Use case 1 - isolated small cities connected only to some of outside connections but not to all. Vanilla game doesn't check if a connection is reachable so trucks appear and disappear when they can't find path.

Use case 2 - I want to export only through trains though my city is connected to road to accept tourists.

It took me 4 hours.